### PR TITLE
Проверка наличия userstate при таймуте quiz

### DIFF
--- a/handlers/quiz.py
+++ b/handlers/quiz.py
@@ -208,6 +208,10 @@ async def poll_handler(
 
     state = dp.fsm.get_context(bot=bot, chat_id=chat_id, user_id=user_id)
     user_data = await state.get_data()
+    user_state = await state.get_state()
+
+    if user_state is None:
+        return
 
     if not user_data.get("has_answered", False):
         lang = user_data.get("language", "en")

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -135,7 +135,13 @@ async def check_poll_timeout(
 ) -> None:
     """Проверяет, ответил ли пользователь на опрос за отведенное время."""
     await asyncio.sleep(config.QUIZ_ANSWER_TIMEOUT)
+
     user_data = await state.get_data()
+    user_state = await state.get_state()
+
+    if user_state is None:
+        return
+
     if not user_data.get("has_answered", False):
         lang = user_data.get("language", "en")
         group_chat_id = user_data.get("group_chat_id")


### PR DESCRIPTION
В случае неверного ответа state зануляется и при срабатывании события таймаута его нет. Условие has_answered == false выполняется сообщение выводится лишний раз. Решение: проверять state на его наличие.